### PR TITLE
Small markdown syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ see: [src/canvasStyles.js](https://github.com/emiliorizzo/vue-d3-network/blob/ma
 ## TODO
 
 - [x]  Touch support
-- []   Optimization
-- []   Zoom
+- [ ]   Optimization
+- [ ]   Zoom
 - [x]  Canvas Render
 - [x]  Nodes sprites
 


### PR DESCRIPTION
I just fixed the markdown syntax of the not yet done items in the TODO section of the README.